### PR TITLE
Use field with datestamp in UTC for sales dates

### DIFF
--- a/ticket-info.js
+++ b/ticket-info.js
@@ -29,8 +29,8 @@ function parseMediatorData(data) {
 				"on_sale_status": item.on_sale_status
 			},
 			"dates": {
-				"sales_start": new Date(item.start_sales).toLocaleString(),
-				"sales_end": new Date(item.end_sales).toLocaleString()
+				"sales_start": new Date(item.start_sales_with_tz.utc).toLocaleString(),
+				"sales_end": new Date(item.end_sales_with_tz.utc).toLocaleString()
 			}
 		};
 	});


### PR DESCRIPTION
The field currently in use for reporting sales start and end is erroneously including the UTC timezone indicator `Z`. It is not in fact in UTC, but localized.

This change uses the keys which are actually in UTC in order to properly report the dates.